### PR TITLE
libtcmu: Fix memory accounting

### DIFF
--- a/scsi.cpp
+++ b/scsi.cpp
@@ -183,7 +183,7 @@ int tcmu_emulate_evpd_inquiry(
 	{
 		char data[512];
 		char *ptr, *p, *wwn;
-		size_t len, used = 0;
+		size_t len, used = 4;
 		uint16_t *tot_len = (uint16_t*) &data[2];
 		uint32_t padding;
 		bool next;
@@ -207,7 +207,7 @@ int tcmu_emulate_evpd_inquiry(
 
 		ptr[3] = 8 + len + 1;
 		used += (uint8_t)ptr[3] + 4;
-		ptr += used;
+		ptr += (uint8_t)ptr[3] + 4;
 
 		/* 2/5: NAA binary */
 		ptr[0] = 1; /* code set: binary */
@@ -340,9 +340,9 @@ int tcmu_emulate_evpd_inquiry(
 finish_page83:
 		/* Done with descriptor list */
 
-		*tot_len = htobe16(used);
+		*tot_len = htobe16(used - 4);
 
-		tcmu_memcpy_into_iovec(iovec, iov_cnt, data, used + 4);
+		tcmu_memcpy_into_iovec(iovec, iov_cnt, data, used);
 
 		free(wwn);
 		wwn = NULL;


### PR DESCRIPTION
The accounting for used memory in `data` was off by 4, as it seemed to be thought as relative to `&data[4]`, but then it used to calculate how many bytes in `data` are still available, and the result was passed to `snprintf`. Glibc with some fortification flags enabled has its own way of figuring out how many bytes are really left in the buffer and bails out with a buffer overflow error if its calculation result ends up lower than the value passed to `snprintf`.

Upstream PR: https://github.com/open-iscsi/tcmu-runner/pull/711