### PR TITLE
silently ignore netlink events for unmatched subtypes

### DIFF
--- a/docs/adr/0001-silent-ignore-unmatched-subtype.md
+++ b/docs/adr/0001-silent-ignore-unmatched-subtype.md
@@ -1,0 +1,36 @@
+# ADR 0001: Silent Ignore for Unmatched Subtype TCMU Device Requests
+
+## Status
+
+Accepted
+
+## Context
+
+In a multi-instance TCMU deployment, multiple user-space processes each register handlers for different subtypes. The kernel broadcasts `TCMU_CMD_ADDED_DEVICE`, `TCMU_CMD_REMOVED_DEVICE`, and `TCMU_CMD_RECONFIG_DEVICE` via Netlink multicast to all listeners in the "config" group.
+
+Previously, when a process received a device event for a subtype it did not handle, it would:
+
+1. Attempt `device_add()`, fail at `find_handler()`, and return `-ENOENT`
+2. Send a Netlink reply (`TCMU_CMD_ADDED_DEVICE_DONE`) with the error code back to the kernel
+3. Log an `ERROR`-level message
+
+This caused the kernel to interpret the response as a device creation failure, potentially preventing the correct handler process from claiming the device.
+
+## Decision
+
+When receiving a TCMU device event for a subtype not registered by this process, **silently ignore the message without sending a Netlink reply**. The specific rules are:
+
+1. **ADDED_DEVICE**: `device_add()` returns `-ENODATA` (not `-ENOENT`) when `find_handler()` yields no match. `handle_netlink()` skips `send_netlink_reply()` for this return value.
+2. **REMOVED_DEVICE / RECONFIG_DEVICE**: If the device is not in `ctx->devices` (i.e., never claimed by this process), skip the Netlink reply.
+3. **Logging**: Subtype mismatch is logged at `DEBUG` level, not `ERROR`. This is expected behavior in multi-instance deployments, not a failure condition.
+
+The return value convention:
+- `-ENODATA`: "No handler registered for this subtype" — caller must not reply
+- `-ENOENT` / other negatives: "Handler was found but processing failed" — caller should reply with the error
+
+## Consequences
+
+- **Enables multi-instance deployment**: Each process only responds to its own subtypes; the kernel receives exactly one reply from the correct handler.
+- **Kernel timeout risk**: If no process handles a given subtype, the kernel will receive no reply and may timeout. This is acceptable — it correctly reflects that no user-space handler is available.
+- **Reduced log noise**: Production logs no longer contain spurious ERROR entries for normal cross-subtype traffic.
+- **Backward compatible**: Netlink v1 never sent replies anyway; this change only affects v2+ reply behavior for unmatched subtypes.

--- a/libtcmu.cpp
+++ b/libtcmu.cpp
@@ -48,8 +48,8 @@ static struct nla_policy tcmu_attr_policy[TCMU_ATTR_MAX+1] = {
 
 static int device_add(struct tcmulib_context *ctx, char *dev_name,
 		      char *cfgstring, bool reopen);
-static void device_remove(struct tcmulib_context *ctx, char *dev_name,
-			  bool should_block);
+static int device_remove(struct tcmulib_context *ctx, char *dev_name,
+			 bool should_block);
 static int handle_netlink(struct nl_cache_ops *unused, struct genl_cmd *cmd,
 			  struct genl_info *info, void *arg);
 
@@ -148,9 +148,9 @@ static int reconfig_device(struct tcmulib_context *ctx, char *dev_name,
 
 	dev = lookup_dev_by_name(ctx, dev_name);
 	if (!dev) {
-		LOG_ERROR("Could not reconfigure device `: not found.",
+		LOG_DEBUG("skipping reconfig for device `: not managed by us",
 			 dev_name);
-		return -ENODEV;
+		return -ENODATA;
 	}
 
 	if (info->attrs[TCMU_ATTR_DEV_CFG]) {
@@ -217,8 +217,7 @@ static int handle_netlink(struct nl_cache_ops *unused, struct genl_cmd *cmd,
 		break;
 	case TCMU_CMD_REMOVED_DEVICE:
 		reply_cmd = TCMU_CMD_REMOVED_DEVICE_DONE;
-		device_remove(ctx, buf, false);
-		ret = 0;
+		ret = device_remove(ctx, buf, false);
 		break;
 	case TCMU_CMD_RECONFIG_DEVICE:
 		reply_cmd = TCMU_CMD_RECONFIG_DEVICE_DONE;
@@ -230,7 +229,7 @@ static int handle_netlink(struct nl_cache_ops *unused, struct genl_cmd *cmd,
 		return -EOPNOTSUPP;
 	}
 
-	if (version > 1)
+	if (version > 1 && ret != -ENODATA)
 		ret = send_netlink_reply(ctx, reply_cmd,
 				nla_get_u32(info->attrs[TCMU_ATTR_DEVICE_ID]),
 				ret);
@@ -364,7 +363,9 @@ static struct tcmulib_handler *find_handler(struct tcmulib_context *ctx,
 	len = found_at - cfgstring;
 
 	for (size_t i = 0; i < ctx->handlers.size(); i++) {
-		if (!strncmp(cfgstring, ctx->handlers[i].subtype, len)) {
+		if (strlen(ctx->handlers[i].subtype) == len &&
+		    !strncmp(cfgstring, ctx->handlers[i].subtype, len)) {
+			LOG_INFO("find handler for subtype: `", cfgstring);
 			return &ctx->handlers[i];
 		}
 	}
@@ -557,8 +558,10 @@ static int device_add(struct tcmulib_context *ctx, char *dev_name,
 
 	dev->handler = find_handler(ctx, dev->cfgstring);
 	if (!dev->handler) {
-		LOG_ERROR("could not find handler for `", dev->dev_name);
-		goto err_free;
+		LOG_WARN("skipping device `: no matching handler for subtype",
+			 dev->dev_name);
+		delete dev;
+		return -ENODATA;
 	}
 
 	if (dev->handler->check_config &&
@@ -630,15 +633,16 @@ static void close_devices(struct tcmulib_context *ctx)
 	}
 }
 
-static void device_remove(struct tcmulib_context *ctx, char *dev_name,
-			  bool should_block)
+static int device_remove(struct tcmulib_context *ctx, char *dev_name,
+			 bool should_block)
 {
 	struct tcmu_device *dev;
 
 	dev = lookup_dev_by_name(ctx, dev_name);
 	if (!dev) {
-		LOG_ERROR("Could not remove device `: not found.", dev_name);
-		return;
+		LOG_WARN("skipping remove for device `: not managed by us",
+			 dev_name);
+		return -ENODATA;
 	}
 
 	/*
@@ -662,6 +666,7 @@ static void device_remove(struct tcmulib_context *ctx, char *dev_name,
 
 	LOG_DEBUG("[dev `] removed from tcmulib", dev->tcm_dev_name);
 	delete dev;
+	return 0;
 }
 
 static int read_uio_name(const char *uio_dev, char **dev_name)


### PR DESCRIPTION
Do not send netlink reply for device add/remove/reconfig events when the subtype does not match any registered handler. Return -ENODATA to distinguish unclaimed devices from actual failures. Downgrade related logs from ERROR to DEBUG.